### PR TITLE
Issue 60: workaround for locking MG update when scan is running

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-05-30 Jan Kotanski <jankotan@gmail.com>
+	* release checks if Door is not RUNNING before MG update with updataMntGrp
+	* tagged as v3.26.1
+
 2022-05-19 Jan Kotanski <jankotan@gmail.com>
 	* remove default mysql local host
 	* add checks if Door is not RUNNING before MG update

--- a/nxsrecconfig/Release.py
+++ b/nxsrecconfig/Release.py
@@ -20,4 +20,4 @@
 """  NeXus Sardana Recorder Settings - Release """
 
 #: (:obj:`str`) package version
-__version__ = "3.26.0"
+__version__ = "3.26.1"

--- a/nxsrecconfig/Settings.py
+++ b/nxsrecconfig/Settings.py
@@ -1199,11 +1199,7 @@ class Settings(object):
         :returns: string with mntgrp configuration
         :rtype: :obj:`str`
         """
-        if not self.__msp.isDoorRunning(self.__selector.getMacroServer()):
-            return self.__profileManager.updateProfile(False)
-        else:
-            raise Exception(
-                "Door is RUNNING. Cannot update the Measurement Group")
+        return self.__profileManager.updateProfile(False)
 
     def switchProfile(self, toActive=True):
         """ switch to active measurement


### PR DESCRIPTION
It resolves #60 by removing checks of RUNNING door servers.