### PR TITLE
Issue 70: send FATAL, ERROR and WARN logs to stderr by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-03-09 Jan Kotanski <jankotan@gmail.com>
+	* send FATAL, ERROR and WARN logs to stderr by default (#71)
+	* tagged as v3.26.3
+
 2022-06-22 Jan Kotanski <jankotan@gmail.com>
 	* add workaround for etree.tosting bug
 	* tagged as v3.26.2

--- a/nxsrecconfig/Release.py
+++ b/nxsrecconfig/Release.py
@@ -20,4 +20,4 @@
 """  NeXus Sardana Recorder Settings - Release """
 
 #: (:obj:`str`) package version
-__version__ = "3.26.2"
+__version__ = "3.26.3"

--- a/nxsrecconfig/StreamSet.py
+++ b/nxsrecconfig/StreamSet.py
@@ -21,6 +21,7 @@
 
 import sys
 import weakref
+import datetime
 
 
 # (:obj:`bool`) write stream to stdout
@@ -66,7 +67,7 @@ class StreamSet(object):
             if hasattr(streams(), "log_debug"):
                 self.log_debug = streams().log_debug
 
-    def fatal(self, message, std=stderrflag):
+    def fatal(self, message, std=None):
         """ writes fatal error message
 
         :param message: error message
@@ -75,16 +76,19 @@ class StreamSet(object):
                     when log stream does not exist
         :type std: :obj:`bool`
         """
+        if std is None:
+            std = stderrflag
         try:
             if self.log_fatal:
                 self.log_fatal.write(message + '\n')
-            elif std:
-                sys.stderr.write(message + '\n')
+            if std:
+                sys.stderr.write(
+                    "%s: FATAL: %s\n" % (datetime.datetime.now(), message))
                 sys.stderr.flush()
         except Exception:
             print(message)
 
-    def error(self, message, std=stderrflag):
+    def error(self, message, std=None):
         """ writes error message
 
         :param message: error message
@@ -93,16 +97,19 @@ class StreamSet(object):
                     when log stream does not exist
         :type std: :obj:`bool`
         """
+        if std is None:
+            std = stderrflag
         try:
             if self.log_error:
                 self.log_error.write(message + '\n')
-            elif std:
-                sys.stderr.write(message + '\n')
+            if std:
+                sys.stderr.write(
+                    "%s: ERROR: %s\n" % (datetime.datetime.now(), message))
                 sys.stderr.flush()
         except Exception:
             print(message)
 
-    def warn(self, message, std=stderrflag):
+    def warn(self, message, std=None):
         """ writes warning message
 
         :param message: warning message
@@ -111,16 +118,19 @@ class StreamSet(object):
                     when log stream does not exist
         :type std: :obj:`bool`
         """
+        if std is None:
+            std = stderrflag
         try:
             if self.log_warn:
                 self.log_warn.write(message + '\n')
-            elif std:
-                sys.stderr.write(message + '\n')
+            if std:
+                sys.stderr.write(
+                    "%s: WARNING: %s\n" % (datetime.datetime.now(), message))
                 sys.stderr.flush()
         except Exception:
             print(message)
 
-    def info(self, message, std=stdoutflag):
+    def info(self, message, std=None):
         """ writes info message
 
         :param message: info message
@@ -129,16 +139,19 @@ class StreamSet(object):
                     when log stream does not exist
         :type std: :obj:`bool`
         """
+        if std is None:
+            std = stdoutflag
         try:
             if self.log_info:
                 self.log_info.write(message + '\n')
             elif std:
-                sys.stdout.write(message + '\n')
+                sys.stdout.write(
+                    "%s: INFO: %s\n" % (datetime.datetime.now(), message))
                 sys.stdout.flush()
         except Exception:
             print(message)
 
-    def debug(self, message, std=stdoutflag):
+    def debug(self, message, std=None):
         """ writes debug message
 
         :param message: debug message
@@ -147,11 +160,14 @@ class StreamSet(object):
                     when log stream does not exist
         :type std: :obj:`bool`
        """
+        if std is None:
+            std = stdoutflag
         try:
             if self.log_debug:
                 self.log_debug.write(message + '\n')
             elif std:
-                sys.stdout.write(message + '\n')
+                sys.stdout.write(
+                    "%s: DEBUG: %s\n" % (datetime.datetime.now(), message))
                 sys.stdout.flush()
         except Exception:
             print(message)

--- a/test/StreamSet_test.py
+++ b/test/StreamSet_test.py
@@ -72,7 +72,7 @@ class StreamSetTest(unittest.TestCase):
         self.streams = None
 
     def getRandomString(self, maxsize):
-        letters = [chr(i) for i in range(256)]
+        letters = [chr(i) for i in range(32, 126)]
         size = self.__rnd.randint(1, maxsize)
         return ''.join(self.__rnd.choice(letters) for _ in range(size))
 
@@ -139,7 +139,9 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_info, None)
             self.assertEqual(self.streams.log_debug, None)
             self.assertEqual(self.mystdout.getvalue(), "")
-            self.assertEqual(self.mystderr.getvalue(), name + '\n')
+            self.assertEqual(
+                self.mystderr.getvalue().split(" ", 2)[-1],
+                "FATAL: " + name + '\n')
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
 
@@ -185,7 +187,16 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_info.getvalue(), "")
             self.assertEqual(self.streams.log_debug.getvalue(), "")
             self.assertEqual(self.mystdout.getvalue(), "")
-            self.assertEqual(self.mystderr.getvalue(), "")
+            if i % 3 == 0:
+                self.assertEqual(
+                    self.mystderr.getvalue().split(" ", 2)[-1],
+                    "FATAL: " + name + '\n')
+            elif i % 3 == 1:
+                self.assertEqual(self.mystderr.getvalue(), '')
+            elif i % 3 == 2:
+                self.assertEqual(
+                    self.mystderr.getvalue().split(" ", 2)[-1],
+                    "FATAL: " + name + '\n')
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
 
@@ -206,7 +217,9 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_info, None)
             self.assertEqual(self.streams.log_debug, None)
             self.assertEqual(self.mystdout.getvalue(), "")
-            self.assertEqual(self.mystderr.getvalue(), name + '\n')
+            self.assertEqual(
+                self.mystderr.getvalue().split(" ", 2)[-1],
+                "ERROR: " + name + '\n')
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
 
@@ -254,7 +267,16 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_info.getvalue(), "")
             self.assertEqual(self.streams.log_debug.getvalue(), "")
             self.assertEqual(self.mystdout.getvalue(), "")
-            self.assertEqual(self.mystderr.getvalue(), "")
+            if i % 3 == 0:
+                self.assertEqual(
+                    self.mystderr.getvalue().split(" ", 2)[-1],
+                    "ERROR: " + name + '\n')
+            elif i % 3 == 1:
+                self.assertEqual(self.mystderr.getvalue(), '')
+            elif i % 3 == 2:
+                self.assertEqual(
+                    self.mystderr.getvalue().split(" ", 2)[-1],
+                    "ERROR: " + name + '\n')
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
 
@@ -275,7 +297,9 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_info, None)
             self.assertEqual(self.streams.log_debug, None)
             self.assertEqual(self.mystdout.getvalue(), "")
-            self.assertEqual(self.mystderr.getvalue(), name + '\n')
+            self.assertEqual(
+                self.mystderr.getvalue().split(" ", 2)[-1],
+                "WARNING: " + name + '\n')
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
 
@@ -321,7 +345,16 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_info.getvalue(), "")
             self.assertEqual(self.streams.log_debug.getvalue(), "")
             self.assertEqual(self.mystdout.getvalue(), "")
-            self.assertEqual(self.mystderr.getvalue(), "")
+            if i % 3 == 0:
+                self.assertEqual(
+                    self.mystderr.getvalue().split(" ", 2)[-1],
+                    "WARNING: " + name + '\n')
+            elif i % 3 == 1:
+                self.assertEqual(self.mystderr.getvalue(), '')
+            elif i % 3 == 2:
+                self.assertEqual(
+                    self.mystderr.getvalue().split(" ", 2)[-1],
+                    "WARNING: " + name + '\n')
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
 
@@ -338,7 +371,9 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_warn, None)
             self.assertEqual(self.streams.log_info, None)
             self.assertEqual(self.streams.log_debug, None)
-            self.assertEqual(self.mystdout.getvalue(), name + '\n')
+            self.assertEqual(
+                self.mystdout.getvalue().split(" ", 2)[-1],
+                "INFO: " + name + '\n')
             self.assertEqual(self.mystderr.getvalue(), "")
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr
@@ -407,7 +442,9 @@ class StreamSetTest(unittest.TestCase):
             self.assertEqual(self.streams.log_warn, None)
             self.assertEqual(self.streams.log_info, None)
             self.assertEqual(self.streams.log_debug, None)
-            self.assertEqual(self.mystdout.getvalue(), name + '\n')
+            self.assertEqual(
+                self.mystdout.getvalue().split(" ", 2)[-1],
+                "DEBUG: " + name + '\n')
             self.assertEqual(self.mystderr.getvalue(), "")
             sys.stdout = self.old_stdout
             sys.stderr = self.old_stderr


### PR DESCRIPTION
It resolves #70 by sending FATAL, ERROR and WARN logs to stderr by default